### PR TITLE
multi: Fix bug and update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,45 @@
-# scomp
-SCOMP is a Graphql computational service that grade students according to thier respective scores in reported subjects. 
+# scomp 
+SCOMP is a Graphql based computational service that computes class student
+records and grade students according to their respective scores in reported
+subjects. 
+
+# Features ⚡
+1. Create an admin account.
+2. Login to existing admin account.
+3. Create a class.
+4. Add a student record to a an existing class.
+5. Compute class report.
+6. Query class record
+7. Query student record
+8. Query all existing classes.
+
+# Limitations ⚠️
+
+1. Class must contain at least 2 students to compute class report.
+2. Class reports can only be generated once.
+3. Student records cannot be added to a class after a report has been generated
+   for that class.
+4. To use this service for the same class with another set of students, classes
+should be created with names formatted like `ClassName Year`, e.g `JSS1 2024`
+etc. Then students for the newly created class should be added (minimum of 2).
+5. Admin would need to request for `classReport` in intervals. e.g every 10
+   minutes. This is because report computation is done asynchronously.
+
+# Starting the Server: Perquisites 💻
+
+1. Go installed.
+2. A database connection URL from mongodb.com
+
+
+# How to start the application server 🚀
+
+1. Ensure the latest version of `go` is installed on your device. Visit
+   https://go.dev/doc/install to install `go`.
+
+2. Clone this repo to your local device and run `cd scomp` on your terminal.
+
+3. Set value for environment variable `DB_URL` {required} and `PORT` {optional, default: `8080`}.
+
+3. Lastly, run `go build` to build the executable and then run `./scomp --dev {remove --dev for production}` to start the HTTP server.
+
+4. Visit `localhost:PORT` to view the Graphql playground.

--- a/server.go
+++ b/server.go
@@ -48,7 +48,7 @@ func main() {
 		log.Fatalf("mongodb.New error: %v", err)
 	}
 
-	resolver, err := graph.NewResolver(nil)
+	resolver, err := graph.NewResolver(db)
 	if err != nil {
 		log.Fatalf("graph.NewResolver error: %v", err)
 	}


### PR DESCRIPTION
This PR fixes a bug where the required `db`  argument was not passed to `graph.NewResolver`. This was introduced in a previous commit where we intended to test without connecting the database.