### PR TITLE
Reduce go mod to v1.22.3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ukane-philemon/scomp
 
-go 1.22.4
+go 1.22.3
 
 require (
 	github.com/99designs/gqlgen v0.17.49


### PR DESCRIPTION
This PR reduces the Go mod version to allow deployment on render.